### PR TITLE
Prevent NPE when when no edits and no output file present

### DIFF
--- a/diff_annotate/__init__.py
+++ b/diff_annotate/__init__.py
@@ -279,14 +279,16 @@ def main(input, output):
 
         diff = insert_annotations(diff, annotations)
 
-    diff = click.edit(diff, extension='.diff')
+    mod_diff = click.edit(diff, extension='.diff')
 
-    if not diff and exists:
-        click.echo('No change, aborting')
-        sys.exit(0)
+    if not mod_diff:
+        if exists:
+            click.echo('No change, aborting')
+            sys.exit(0)
+        mod_diff = diff;
 
-    annotations = parse_annotations_in_diff(diff)
-    html = formatHTML(diff, annotations)
+    annotations = parse_annotations_in_diff(mod_diff)
+    html = formatHTML(mod_diff, annotations)
 
     with open(output, 'w') as fp:
         fp.write(html)


### PR DESCRIPTION
This is not a functional change, but it freaked me out when I started using diff-annotate.
To reproduce the problem, take any diff file, run diff-annotate on it, with non-existing HTML, and exit the editor without making changes. diff-annotate will bork because there are no changes and no HTML. IMHO, it should just write HTML as is.
